### PR TITLE
Prepare documents on server start

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ repository](https://github.com/ubleipzig/histvv-data) follow these steps:
 ```bash
 git clone https://github.com/ubleipzig/histvv-data.git
 basex -c 'set chop false; create db histvv ./histvv-data/xml'
-# NB: the next command can take serveral minutes
-basex -i histvv https://raw.githubusercontent.com/ubleipzig/histvv/master/xqy/annotate.xq
 ```
 
 ## Options

--- a/annotate.js
+++ b/annotate.js
@@ -28,7 +28,7 @@ const async = require('async');
 
 const xqFindDocs =
   'declare namespace v = "http://histvv.uni-leipzig.de/ns/2007";' +
-  '/v:vv[not(@x-semester)]/base-uri()';
+  '/v:vv[not(@semester)]/base-uri()';
 
 const queryfile = path.join(__dirname, 'xqy', 'annotate.xq');
 const xqAnnotate = fs.readFileSync(queryfile, 'utf-8');

--- a/annotate.js
+++ b/annotate.js
@@ -1,0 +1,66 @@
+/*
+ * annotate.js
+ *
+ * Copyright (C) 2019 Leipzig University Library <info@ub.uni-leipzig.de>
+ *
+ * Author: Carsten Milling <cmil@hashtable.de>
+ *
+ * This file is part of histvv.
+ *
+ * Histvv is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Histvv is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const async = require('async');
+
+const xqFindDocs =
+  'declare namespace v = "http://histvv.uni-leipzig.de/ns/2007";' +
+  '/v:vv[not(@x-semester)]/base-uri()';
+
+const queryfile = path.join(__dirname, 'xqy', 'annotate.xq');
+const xqAnnotate = fs.readFileSync(queryfile, 'utf-8');
+
+module.exports = function (dbSession) {
+  return new Promise((resolve, reject) => {
+    const queryFind = dbSession.query(xqFindDocs);
+    const queryAnnotate = dbSession.query(xqAnnotate);
+
+    queryFind.execute((err, r) => {
+      if (err) {
+        return reject(err);
+      }
+      const uris = r.result ? r.result.split('\n') : [];
+      if (uris.length > 0) {
+        console.log('Annotating documents...');
+      }
+      async.each(uris, (uri, cb) => {
+        queryAnnotate.bind('uri', uri, '');
+        queryAnnotate.execute(err => {
+          if (err) {
+            return cb(err);
+          }
+          console.log(`${uri}`);
+          cb();
+        });
+      }, err => {
+        if (err) {
+          return reject(err);
+        }
+        resolve(uris.length);
+      });
+    });
+  });
+};

--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@ const path = require('path');
 const express = require('express');
 const logger = require('morgan');
 const basex = require('basex');
+const annotate = require('./annotate');
 const staticHtml = require('./static');
 const finish = require('./finish');
 const config = require('./config');
@@ -43,6 +44,11 @@ session.execute('OPEN ' + config.db.name, (err, r) => {
     throw err;
   }
   console.log(r.info);
+  annotate(session).then(n => {
+    console.log('all documents prepared (%s new)', n);
+  }).catch(error => {
+    console.warn(error);
+  });
 });
 
 const routeHandlerFactory = require('./routehandler.js')(session);

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,9 +238,12 @@
       "dev": true
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "requires": {
+        "lodash": "^4.17.10"
+      }
     },
     "async-each": {
       "version": "1.0.1",
@@ -3236,8 +3239,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -3659,6 +3661,13 @@
         "ini": "^1.3.0",
         "secure-keys": "^1.0.0",
         "yargs": "^3.19.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
       }
     },
     "negotiator": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "histvv-server": "bin/www"
   },
   "dependencies": {
+    "async": "^2.6.1",
     "basex": "0.9.0",
     "debug": "4.0.1",
     "express": "^4.16.3",

--- a/xqy/annotate.xq
+++ b/xqy/annotate.xq
@@ -23,8 +23,9 @@
  :
  : annotate.xq adds the following attributes to `vv` documents in the
  : database:
- :  - `x-semester` to the `vv` elements
- :  - `x-text`, `x-thema`, `x-dozenten`, `x-dozentenrefs` to `veranstaltung`
+ :
+ :  - `@semester` to the `vv` elements
+ :  - `@fulltext`, `@thema`, `@dozenten`, `@dozentenrefs` to `veranstaltung`
  :    elements
  :)
 
@@ -103,16 +104,19 @@ let $doc := doc($uri)
 
 return (
   (: delete exisiting attributes :)
-  delete node $doc/vv/@x-semester,
-  delete node $doc//veranstaltung/@x-text,
-  delete node $doc//veranstaltung/@x-thema,
-  delete node $doc//veranstaltung/@x-dozenten,
-  delete node $doc//veranstaltung/@x-dozentenrefs,
+  delete node $doc/vv/@semester,
+  delete node $doc//veranstaltung/@fulltext,
+  delete node $doc//veranstaltung/@thema,
+  delete node $doc//veranstaltung/@dozenten,
+  delete node $doc//veranstaltung/@dozentenrefs,
 
-  (: insert x-semester :)
-  insert node attribute x-semester {local:semid($doc/vv)} into $doc/vv,
+  (: insert semester :)
+  insert node attribute semester {local:semid($doc/vv)} into $doc/vv,
 
-  (: insert x-text, x-thema, x-dozenten, and x-dozentenrefs into :)
+  (:
+   : insert @fulltext, @thema, @dozenten, and @dozentenrefs into
+   : `veranstaltung`
+   :)
   for $v in $doc//veranstaltung
 
   (: gather relevant `thema` elements :)
@@ -135,21 +139,21 @@ return (
       ancestor::veranstaltungsgruppe[ders][1]/ders)
     ) ! local:resolve-ders(.)
 
-  let $x-thema := string-join(
+  let $thema := string-join(
     ($sg, $themen) ! local:strip-text(., 'anmerkung'),
     ' … '
   )
 
-  let $x-dozenten := string-join(
+  let $dozenten-attr := string-join(
     ($dozenten
       ! (if (name(.)='ders') then () else .)
       ! local:strip-text(.)
     ), '; '
   )
 
-  let $x-dozentenrefs := string-join($dozenten/@ref, ' ')
+  let $dozentenrefs := string-join($dozenten/@ref, ' ')
 
-  let $x-text := string-join(
+  let $fulltext := string-join(
     (
       $v,
       $themen except $v/thema,
@@ -160,9 +164,9 @@ return (
   )
 
   return (
-    insert node attribute x-text {$x-text} into $v,
-    insert node attribute x-thema {$x-thema} into $v,
-    insert node attribute x-dozenten {$x-dozenten} into $v,
-    insert node attribute x-dozentenrefs {$x-dozentenrefs} into $v
+    insert node attribute fulltext {$fulltext} into $v,
+    insert node attribute thema {$thema} into $v,
+    insert node attribute dozenten {$dozenten-attr} into $v,
+    insert node attribute dozentenrefs {$dozentenrefs} into $v
   )
 )

--- a/xqy/annotate.xq
+++ b/xqy/annotate.xq
@@ -30,6 +30,8 @@
 
 declare default element namespace 'http://histvv.uni-leipzig.de/ns/2007';
 
+declare variable $uri external;
+
 (:~
  : Construct semester ID
  :
@@ -97,73 +99,70 @@ as element() {
   else $elem
 };
 
-(:
- : 1. delete exisiting attributes
- :)
-delete node //vv/@x-semester,
-delete node //veranstaltung/@x-text,
-delete node //veranstaltung/@x-thema,
-delete node //veranstaltung/@x-dozenten,
-delete node //veranstaltung/@x-dozentenrefs,
-
-(:
- : 2. insert x-semester
- :)
- for $vv in //vv
- return insert node attribute x-semester {local:semid($vv)} into $vv,
-
-(:
- : 3. insert x-text, x-thema, x-dozenten, and x-dozentenrefs into
- :)
-for $v in //veranstaltung
-
-(: gather relevant `thema` elements :)
-let $themen := $v/(ancestor::veranstaltungsgruppe/thema | thema)
-
-(: use title of `sachgruppe` if there is no `thema` or the `thema` is
- : connected via the `kontext` attribute
- :
- : TODO: follow sachgruppe/titel/@kontext
- :)
-let $sg := if (count($themen) = 0 or $v/thema[@kontext])
-           then $v/ancestor::sachgruppe[1]/titel
-           else ()
-
-let $dozenten := (
-  if ($v/(dozent|ders))
-  then $v/(dozent|ders)
-  else $v/(
-    ancestor::veranstaltungsgruppe/dozent[last()] |
-    ancestor::veranstaltungsgruppe[ders][1]/ders)
-  ) ! local:resolve-ders(.)
-
-let $x-thema := string-join(
-  ($sg, $themen) ! local:strip-text(., 'anmerkung'),
-  ' … '
-)
-
-let $x-dozenten := string-join(
-  ($dozenten
-    ! (if (name(.)='ders') then () else .)
-    ! local:strip-text(.)
-  ), '; '
-)
-
-let $x-dozentenrefs := string-join($dozenten/@ref, ' ')
-
-let $x-text := string-join(
-  (
-    $v,
-    $themen except $v/thema,
-    $sg,
-    $dozenten except $v/dozent
-  ) ! local:strip-text(.),
-  ' | '
-)
+let $doc := doc($uri)
 
 return (
-  insert node attribute x-text {$x-text} into $v,
-  insert node attribute x-thema {$x-thema} into $v,
-  insert node attribute x-dozenten {$x-dozenten} into $v,
-  insert node attribute x-dozentenrefs {$x-dozentenrefs} into $v
+  (: delete exisiting attributes :)
+  delete node $doc/vv/@x-semester,
+  delete node $doc//veranstaltung/@x-text,
+  delete node $doc//veranstaltung/@x-thema,
+  delete node $doc//veranstaltung/@x-dozenten,
+  delete node $doc//veranstaltung/@x-dozentenrefs,
+
+  (: insert x-semester :)
+  insert node attribute x-semester {local:semid($doc/vv)} into $doc/vv,
+
+  (: insert x-text, x-thema, x-dozenten, and x-dozentenrefs into :)
+  for $v in $doc//veranstaltung
+
+  (: gather relevant `thema` elements :)
+  let $themen := $v/(ancestor::veranstaltungsgruppe/thema | thema)
+
+  (: use title of `sachgruppe` if there is no `thema` or the `thema` is
+   : connected via the `kontext` attribute
+   :
+   : TODO: follow sachgruppe/titel/@kontext
+   :)
+  let $sg := if (count($themen) = 0 or $v/thema[@kontext])
+             then $v/ancestor::sachgruppe[1]/titel
+             else ()
+
+  let $dozenten := (
+    if ($v/(dozent|ders))
+    then $v/(dozent|ders)
+    else $v/(
+      ancestor::veranstaltungsgruppe/dozent[last()] |
+      ancestor::veranstaltungsgruppe[ders][1]/ders)
+    ) ! local:resolve-ders(.)
+
+  let $x-thema := string-join(
+    ($sg, $themen) ! local:strip-text(., 'anmerkung'),
+    ' … '
+  )
+
+  let $x-dozenten := string-join(
+    ($dozenten
+      ! (if (name(.)='ders') then () else .)
+      ! local:strip-text(.)
+    ), '; '
+  )
+
+  let $x-dozentenrefs := string-join($dozenten/@ref, ' ')
+
+  let $x-text := string-join(
+    (
+      $v,
+      $themen except $v/thema,
+      $sg,
+      $dozenten except $v/dozent
+    ) ! local:strip-text(.),
+    ' | '
+  )
+
+  return (
+    insert node attribute x-text {$x-text} into $v,
+    insert node attribute x-thema {$x-thema} into $v,
+    insert node attribute x-dozenten {$x-dozenten} into $v,
+    insert node attribute x-dozentenrefs {$x-dozentenrefs} into $v
+  )
 )

--- a/xqy/dozent.xq
+++ b/xqy/dozent.xq
@@ -27,7 +27,7 @@ declare variable $id external := "anger_r";
 
 let $daten := /v:dozentenliste/v:dozent[@xml:id=$id]
 let $veranstaltungen := /v:vv[v:kopf/v:status/@komplett]
-  //v:veranstaltung[tokenize(@x-dozentenrefs, "\s+") = $id]
+  //v:veranstaltung[tokenize(@dozentenrefs, "\s+") = $id]
 
 return
 if ($daten) then
@@ -36,7 +36,7 @@ if ($daten) then
   <stellen>
   {
     for $v in $veranstaltungen return
-    <stelle semester="{$v/ancestor::v:vv/@x-semester}">
+    <stelle semester="{$v/ancestor::v:vv/@semester}">
     {$v}
     {
      if ($v/v:dozent[@ref = $id])

--- a/xqy/suche.xq
+++ b/xqy/suche.xq
@@ -35,7 +35,7 @@ let $start := if (number($start) > 0) then number($start) else 1
 let $interval := if (number($interval) >= 10 and number($interval) <= 200)
   then number($interval) else 50
 
-let $sems := /v:vv/@x-semester/data()
+let $sems := /v:vv/@semester/data()
 let $semcount := count($sems)
 let $min-sem := $sems[1]
 let $max-sem := $sems[$semcount]
@@ -47,16 +47,16 @@ let $bis := if(
     matches($bis, '^[0-9]{4}[ws]$') and $bis >= $min-sem and $bis <= $max-sem
   ) then $bis else $max-sem
 
-let $stellen := /v:vv[@x-semester >= $von and @x-semester <= $bis]
+let $stellen := /v:vv[@semester >= $von and @semester <= $bis]
   //v:sachgruppe[
     @fakultät and (@fakultät = tokenize($fakultaet) or $fakultaet = '')
   ]
   //v:veranstaltung[
     ($volltext = ''
-      or @x-text contains text {tokenize($volltext)} all using stemming
+      or @fulltext contains text {tokenize($volltext)} all using stemming
          using language "German")
     and
-    ($dozent = '' or @x-dozenten contains text {tokenize($dozent)})
+    ($dozent = '' or @dozenten contains text {tokenize($dozent)})
   ]
 
 let $total := count($stellen)
@@ -77,7 +77,7 @@ return
     order by $kopf/v:beginn/v:jahr, $kopf/v:ende/v:jahr
     return
     <stelle id="{$v/@xml:id}" semester="{$sem}" jahr="{$jahr}">
-      <thema>{string($v/@x-thema)}</thema>
+      <thema>{string($v/@thema)}</thema>
       <dozenten>{$dozenten}</dozenten>
       <text>{normalize-space($v)}</text>
     </stelle>

--- a/xqy/suchformular.xq
+++ b/xqy/suchformular.xq
@@ -29,7 +29,7 @@ return
 <formular>
   {
     for $vv in /v:vv
-    let $name := concat($vv/@x-semester, "")
+    let $name := concat($vv/@semester, "")
     let $titel := concat($vv/v:kopf/v:beginn/v:jahr, " ", $vv/v:kopf/v:semester)
     order by $vv/v:kopf/v:beginn/v:jahr, $vv/v:kopf/v:ende/v:jahr
     return

--- a/xsl/dozenten.xsl
+++ b/xsl/dozenten.xsl
@@ -485,7 +485,7 @@
         </a>
       </td>
       <td>
-        <xsl:value-of select="v:veranstaltung/@x-thema"/>
+        <xsl:value-of select="v:veranstaltung/@thema"/>
       </td>
       <td class="grad">
         <xsl:for-each select=".//v:dozent[@ref=$id]/v:grad">


### PR DESCRIPTION
This PR moves the insertion of calculated attributes into the server startup sequence. On server start documents in the database lacking the `@semester` attribute will be updated one document at a time. This make the manual execution of `annotate.xq` obsolete and speeds up the process significantly.

resolves #1